### PR TITLE
Включение Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 30
+    labels:
+      - dependencies


### PR DESCRIPTION
Этот PR включает Dependabot от Github, что позволяет следить за актуальностью зависимостей в репозитории.
Dependabot будет раз в месяц сканировать репозиторий и открывать/актуализировать PRы по обновлению той или иной зависимости.

Пример как это выглядит:
https://github.com/ExpressApp/pybotx/pull/433

Этот же бот был ранее включен в репозитории pybotx, но в режиме сканирования "раз в неделю":
https://github.com/ExpressApp/pybotx/pull/416
